### PR TITLE
Update StatUtils.ts for number formatting + Format numbers used in views

### DIFF
--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -212,7 +212,7 @@ export default class StatsManager {
       this.vaultStats.history[this.today].footnotes = footnotes;
       this.vaultStats.history[this.today].citations = citations;
       this.vaultStats.history[this.today].pages = pages;
-      this.vaultStats.history[this.today].files = this.getTotalFiles();
+      this.vaultStats.history[this.today].files = this.getTotalFileCount();
 
       await this.update();
     } else {
@@ -315,31 +315,47 @@ export default class StatsManager {
     return citations;
   }
 
-  public getDailyWords(): number {
-    return this.vaultStats.history[this.today].words;
+  // Removes floating point errors and adds thousands separators to a number.
+  private formatNumber(number: number): string {
+    if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
+      // Use the user's local settings if available
+      return Math.round(number).toLocaleString();
+    } else {
+      // Default to 'en-US' otherwise
+      return Math.round(number).toLocaleString('en-US');
+    }
   }
 
-  public getDailyCharacters(): number {
-    return this.vaultStats.history[this.today].characters;
+
+  public getDailyWords(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].words);
   }
 
-  public getDailySentences(): number {
-    return this.vaultStats.history[this.today].sentences;
+  public getDailyCharacters(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].characters);
+  }
+
+  public getDailySentences(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].sentences);
   }
 
 
-  public getDailyFootnotes(): number {
-    return this.vaultStats.history[this.today].footnotes;
+  public getDailyFootnotes(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].footnotes);
   }
 
-  public getDailyCitations(): number {
-    return this.vaultStats.history[this.today].citations;
+  public getDailyCitations(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].citations);
   }
-  public getDailyPages(): number {
-    return this.vaultStats.history[this.today].pages;
+  public getDailyPages(): string {
+    return this.formatNumber(this.vaultStats.history[this.today].pages);
   }
 
-  public getTotalFiles(): number {
+  public getTotalFiles(): string {
+    return this.formatNumber(this.vault.getMarkdownFiles().length);
+  }
+
+  public getTotalFileCount(): number {
     return this.vault.getMarkdownFiles().length;
   }
 
@@ -368,8 +384,8 @@ export default class StatsManager {
     return this.vaultStats.history[this.today].totalCitations;
   }
 
-  public async getTotalPages(): Promise<number> {
-    if (!this.vaultStats) return await this.calcTotalPages();
-    return this.vaultStats.history[this.today].totalPages;
+  public async getTotalPages(): Promise<string> {
+    if (!this.vaultStats) return this.formatNumber(await this.calcTotalPages());
+    return this.formatNumber(this.vaultStats.history[this.today].totalPages);
   }
 }

--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -21,11 +21,11 @@ export function getWordCount(text: string): number {
     "g"
   );
   const result = (text.match(pattern) || []).length;
-  return formatNumber(result);
+  return result;
 }
 
 export function getCharacterCount(text: string): number {
-  return formatNumber(text.length);
+  return text.length;
 }
 
 export function getFootnoteCount(text: string): number {
@@ -35,14 +35,14 @@ export function getFootnoteCount(text: string): number {
   let overallFn = 0;
   if (regularFn) overallFn += regularFn.length;
   if (inlineFn) overallFn += inlineFn.length;
-  return formatNumber(overallFn);
+  return overallFn;
 }
 
 export function getCitationCount(text: string): number {
   const pandocCitations = text.match(/@[A-Za-z0-9-]+[,;\]](?!\()/gi);
   if (!pandocCitations) return 0;
   const uniqueCitations = [...new Set(pandocCitations)].length;
-  return formatNumber(uniqueCitations);
+  return uniqueCitations;
 }
 
 export function getSentenceCount(text: string): number {
@@ -51,7 +51,7 @@ export function getSentenceCount(text: string): number {
       /[^.!?\s][^.!?]*(?:[.!?](?!['"]?\s|$)[^.!?]*)*[.!?]?['"]?(?=\s|$)/gm
     ) || []
   ).length;
-  return formatNumber(sentences);
+  return sentences;
 }
 
 export function getPageCount(text: string, pageWords: number): number {
@@ -60,20 +60,9 @@ export function getPageCount(text: string, pageWords: number): number {
 
 export function getTotalFileCount(vault: Vault): number {
   const fileCount = vault.getMarkdownFiles().length;
-  return formatNumber(fileCount);
+  return fileCount;
 }
 
 export function cleanComments(text: string): string {
   return text.replace(MATCH_COMMENT, "").replace(MATCH_HTML_COMMENT, "");
-}
-
-// Removes floating point errors and adds thousands separators to a number.
-function formatNumber(number: number): string {
-  if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
-    // Use the user's local settings if available
-    return Math.round(number).toLocaleString();
-  } else {
-    // Default to 'en-US' otherwise
-    return Math.round(number).toLocaleString('en-US');
-  }
 }

--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -20,11 +20,12 @@ export function getWordCount(text: string): number {
     ].join("|"),
     "g"
   );
-  return (text.match(pattern) || []).length;
+  const result = (text.match(pattern) || []).length;
+  return formatNumber(result);
 }
 
 export function getCharacterCount(text: string): number {
-  return text.length;
+  return formatNumber(text.length);
 }
 
 export function getFootnoteCount(text: string): number {
@@ -34,14 +35,14 @@ export function getFootnoteCount(text: string): number {
   let overallFn = 0;
   if (regularFn) overallFn += regularFn.length;
   if (inlineFn) overallFn += inlineFn.length;
-  return overallFn;
+  return formatNumber(overallFn);
 }
 
 export function getCitationCount(text: string): number {
   const pandocCitations = text.match(/@[A-Za-z0-9-]+[,;\]](?!\()/gi);
   if (!pandocCitations) return 0;
   const uniqueCitations = [...new Set(pandocCitations)].length;
-  return uniqueCitations;
+  return formatNumber(uniqueCitations);
 }
 
 export function getSentenceCount(text: string): number {
@@ -50,8 +51,7 @@ export function getSentenceCount(text: string): number {
       /[^.!?\s][^.!?]*(?:[.!?](?!['"]?\s|$)[^.!?]*)*[.!?]?['"]?(?=\s|$)/gm
     ) || []
   ).length;
-
-  return sentences;
+  return formatNumber(sentences);
 }
 
 export function getPageCount(text: string, pageWords: number): number {
@@ -59,9 +59,21 @@ export function getPageCount(text: string, pageWords: number): number {
 }
 
 export function getTotalFileCount(vault: Vault): number {
-  return vault.getMarkdownFiles().length;
+  const fileCount = vault.getMarkdownFiles().length;
+  return formatNumber(fileCount);
 }
 
 export function cleanComments(text: string): string {
   return text.replace(MATCH_COMMENT, "").replace(MATCH_HTML_COMMENT, "");
+}
+
+// Removes floating point errors and adds thousands separators to a number.
+function formatNumber(number: number): string {
+  if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
+    // Use the user's local settings if available
+    return Math.round(number).toLocaleString();
+  } else {
+    // Default to 'en-US' otherwise
+    return Math.round(number).toLocaleString('en-US');
+  }
 }


### PR DESCRIPTION
From: https://github.com/lukeleppan/better-word-count/pull/114
> I wrote a new function (formatNumber) that removes floating point errors and adds thousands separators to a number, and applied this function to the results of most numeric variables sent to StatusBar.ts
> 
> At the very least, this hopefully resolves #103 and resolves #111
> 
> FYI: I haven't tested this change myself in Obsidian, so I may have missed something.

And: https://github.com/DrYoshiyahu/better-word-count/pull/1
> Builds on @.DrYoshiyahu formatting to always present formatted numbers, and in one case preserving the `number` where it is used for calculations (but not shown to user). Addresses [lukeleppan#103](https://github.com/lukeleppan/better-word-count/issues/103) and [lukeleppan#111](https://github.com/lukeleppan/better-word-count/issues/111)
> 
> This is not the best organization/naming, but it compiles and works as expected.
> 
> Screenshot showing Total Pages (`tp`) and Words per Day (`wpd`) that are properly rounded. ![Screenshot 2024-02-13 at 8 23 53 AM](https://private-user-images.githubusercontent.com/153632/304479834-0b2f9dce-b482-4c1f-9585-d89d4d6ace3e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjE4OTQ3MzEsIm5iZiI6MTcyMTg5NDQzMSwicGF0aCI6Ii8xNTM2MzIvMzA0NDc5ODM0LTBiMmY5ZGNlLWI0ODItNGMxZi05NTg1LWQ4OWQ0ZDZhY2UzZS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzI1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDcyNVQwODAwMzFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05ZDFhM2JkYjZhNjUwMzZlNWZmMzljZDJmYzYyZDdmMmMxYzU2NWQ0MzdlM2UzZDc4MzU5MDZkMzE4YWI3OWZmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.IC31ClGVJoNEBSJ3qSJD_X-RYMh59fPoZSAXO2i1JSY)
> 
> Screenshot showing Current Pages (`p`) and Total Pages (`ppd`) that are properly rounded. ![Screenshot 2024-02-13 at 8 23 43 AM](https://private-user-images.githubusercontent.com/153632/304480229-0a4efe72-ff55-4c7f-a917-56434460b0d9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjE4OTQ3MzEsIm5iZiI6MTcyMTg5NDQzMSwicGF0aCI6Ii8xNTM2MzIvMzA0NDgwMjI5LTBhNGVmZTcyLWZmNTUtNGM3Zi1hOTE3LTU2NDM0NDYwYjBkOS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzI1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDcyNVQwODAwMzFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00NmY4NzU1ZWYzM2YyY2MyZDBjZWM4Mjg1NWU5OWE0ZmJjOGZmOTFhMWEzMWVmYzkwOTkzNTdhZTY2NmExZmI5JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.N1SZOwYu1YADPZaGcDCYerbHB9oy1isb6v1QHjO1pM8)

